### PR TITLE
Prevent showing an image with an empty src

### DIFF
--- a/flag-icon.html
+++ b/flag-icon.html
@@ -26,7 +26,9 @@ A web component that can be used to display flags by passing country name or one
       display: inline-flex;
     }
     </style>
-    <iron-image src="{{src}}" alt="[[title]]" title$="[[title]]" aria-label$="[[title]]" sizing="contain"></iron-image>
+    <template is="dom-if" if="[[src]]" restamp="true">
+      <iron-image src="{{src}}" alt="[[title]]" title$="[[title]]" aria-label$="[[title]]" sizing="contain"></iron-image>
+    </template>
   </template>
   <script>
   'use strict';


### PR DESCRIPTION
When `src` is null it still makes an invalid (404) request to load an image for `null` country.